### PR TITLE
Fixing when branch expressions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
         }
       }
       when {
-        branch '**/master'
+        branch 'master'
       }
       steps {
         sh 'mvn -B clean package -Pintegration'
@@ -52,7 +52,7 @@ pipeline {
         }
       }
       when {
-        branch '**/release-*'
+        branch 'release-*'
       }
       steps {
         sh "mvn -B clean package -Prelease -Dversion='${env.BRANCH_NAME.drop(env.BRANCH_NAME.lastIndexOf('-')+1)}.$BUILD_NUMBER'"


### PR DESCRIPTION
Since `BRANCH_NAME` is the local branch, not including the remote, `*/master` and friends aren't a good idea, so let's switch to just using `master` etc.